### PR TITLE
Fix

### DIFF
--- a/src/Code.gs
+++ b/src/Code.gs
@@ -15,11 +15,11 @@ function doGet(e) {
   if (validPages.indexOf(page) !== -1) {
     contentFile = `content_${page}.html`;
   }
-  template.pageContent = HtmlService.createHtmlOutputFromFile(contentFile).getContent();
+  template.pageContent = HtmlService.createTemplateFromFile(contentFile).getRawContent();
   template.urlParams = e.parameter;
   return template.evaluate().setTitle("Carndonagh Health Centre").setXFrameOptionsMode(HtmlService.XFrameOptionsMode.DEFAULT);
 }
-function include(filename) { return HtmlService.createHtmlOutputFromFile(filename).getContent(); }
+function include(filename) { return HtmlService.createTemplateFromFile(filename).getRawContent(); }
 function onOpen() {
   initializeColumnMap();
   const ui = SpreadsheetApp.getUi();


### PR DESCRIPTION
Fix(gscript): Resolve HTML injection error in template

The `include` function was using `HtmlService.createHtmlOutputFromFile().getContent()`, which was wrapping the content of included files (like javascript and css) in `<html>` and `<body>` tags. This caused a syntax error in the browser when the script was loaded.

The `doGet` function had a similar issue where it was embedding a full HTML document inside the main page template.

This commit fixes both issues by using `HtmlService.createTemplateFromFile().getRawContent()` instead. This method returns the raw content of the file without any extra wrapping, ensuring that the javascript, css, and page content are correctly injected into the main template.